### PR TITLE
Fix lua_e pattern of nyaos.

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -134,7 +134,7 @@ let s:default_filetypes = {
       \ 'int-nyaos': [
       \   {
       \    'start': '\<lua_e\s\+\(["'']\)',
-      \    'end': '^\1', 'filetype': 'lua',
+      \    'end': '\1\@<!\1\1\@!', 'filetype': 'lua',
       \   }
       \ ],
       \ 'lua': [
@@ -150,7 +150,7 @@ let s:default_filetypes = {
       \ 'nyaos': [
       \   {
       \    'start': '\<lua_e\s\+\(["'']\)',
-      \    'end': '^\1', 'filetype': 'lua',
+      \    'end': '\1\@<!\1\1\@!', 'filetype': 'lua',
       \   }
       \ ],
       \ 'perl6': [

--- a/test/test_files/test.ny
+++ b/test/test_files/test.ny
@@ -1,0 +1,13 @@
+
+`nyaos`
+
+lua_e "
+`lua`
+" `nyaos`
+
+lua_e "`lua`" `nyaos`
+
+lua_e "
+print(""`lua`"")
+" `nyaos`
+


### PR DESCRIPTION
```
lua_e "print('a')"

lua_e "
  print('a')
  print('b')"

lua_e "print(""a"")"
```

上記の様な表記方法で閉じられなくなるので修正しました
※ ファイル名が `test.ny` な為 Shougo/vim-nyaos#2 も関連します

---

2回 `\1` が続くのは無視する、の良い正規表現が思いつかず
否定先読と否定後読のダブルコンボ:confused:
