### PR TITLE
ドキュメント修正

### DIFF
--- a/doc/context_filetype.jax
+++ b/doc/context_filetype.jax
@@ -108,28 +108,35 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 		各 filetype を判定する為の辞書です。
 		各 filetype に対してリストで設定する事ができます。
 
-		"filetype" : 判定を行う filetype
 		"start"    : コンテキストの開始パターン
 		"end"      : コンテキストの終了パターン
-		              これに \1 が設定されている場合は "start" にマッ
-		              チした値になります。
+		"filetype" : 判定を行う filetype
+		              "end" または "filetype" に \1 が設定されている場
+			      合は "start" にマッチした値になります。
 >
 		" Examples:
 		let g:context_filetype#filetypes = {
-		\ "perl6" : [
+		\ 'perl6' : [
 		\   {
-		\     'filetype' : 'pir',
 		\     'start' : 'Q:PIR\s*{',
-		\     'end' : '}'
+		\     'end' : '}',
+		\     'filetype' : 'pir',
 		\   }
 		\ ],
-		\ "vim" : [
+		\ 'vim' : [
 		\   {
-		\     'filetype' : 'python',
 		\     'start' : '^\s*python <<\s*\(\h\w*\)',
-		\     'end' : '^\1'
+		\     'end' : '^\1',
+		\     'filetype' : 'python',
 		\   }
-		\ ]
+		\ ],
+		\ 'markdown': [
+		\   {
+		\     'start' : '^\s*```\s*\(\h\w*\)',
+		\     'end' : '^\s*```$',
+		\     'filetype' : '\1',
+		\   },
+		\ ],
 		\}
 <
 


### PR DESCRIPTION
`g:context_filetype#filetypes`　の filetype に `\1` がつかえることの説明がなかったので追記しました。

あとドキュメントで気になるのは、以下の２か所ですが修正方法がわかりませんでした。
- `g:context_filetype#filetypes` : 「`searchpos`...」 と内部の実装方法で説明されても使う人にはわかりません。
- `context_filetype#version()` : Note の意味が分かりません。インストールされていない場合にも正常に動作するのでしょうか?
