### PR TITLE
Add test including multi-byte characters (and failed it)

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -469,7 +469,7 @@ function! s:search_range(start_pattern, end_pattern) "{{{
 
   if end_forward[1] <= 1
     let end_forward[0] -= 1
-    let len = strdisplaywidth(getline(end_forward[0]))
+    let len = len(getline(end_forward[0]))
     let len = len ? len : 1
     let end_forward[1] = len
   endif

--- a/test/test_files/test.md
+++ b/test/test_files/test.md
@@ -70,5 +70,9 @@ EOF
 
     ```
 
+```text
+`text`本日は晴天なり`text`
+```
+
 `markdown`
 


### PR DESCRIPTION
## Reproduction procedure


1. launch vim as the following command line.
    ```console
    echo "\`\`\`text\n本日は晴天なり\n\`\`\`\n" | vim --cmd "setlocal filetype=markdown" -
    ```

2. run `:ec context_filetype#get()` at each position of multi-byte characters.


## Actual

|word|`:ec context_filetype#get()`|
|:-:|-----------------------------------------------|
|本|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|日|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|は|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|晴|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|天|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|な|{'range': [[0, 0], [0, 0]], 'filetype': 'markdown'}|
|り|{'range': [[0, 0], [0, 0]], 'filetype': 'markdown'}|


## Expected


|word|`:ec context_filetype#get()`|
|:-:|-----------------------------------------------|
|本|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|日|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|は|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|晴|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|天|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|な|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|
|り|{'range': [[2, 1], [2, 14]], 'filetype': 'text'}|

## Problem

The last two multi-byte characters seem to fail to determine the filetype.