### PR TITLE
[WIP] Fix cgo support

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -318,8 +318,8 @@ let s:default_filetypes = {
       \ ],
       \ 'go': [
       \   {
-      \    'start': '^\s*/\*$',
-      \    'end': '^\s*\*/\n\s*import\s\+"C"$', 'filetype': 'c',
+      \    'start': '^\s*\/\*\s*$',
+      \    'end': '^\s*\*\/\s*\_.\s*import\s\+"C"$', 'filetype': 'c',
       \   },
       \ ],
 \}"}}}

--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -452,11 +452,15 @@ function! s:search_range(start_pattern, end_pattern) "{{{
   endif
 
   let end_forward = searchpos(end_pattern, 'ncW', stopline_forward)
+  let original_end_forward = end_forward
   if end_forward == s:null_pos
     let end_forward = [line('$'), len(getline('$'))+1]
   endi
 
   let end_backward = searchpos(end_pattern, 'bnW', stopline_back)
+  if original_end_forward == s:null_pos && end_backward == s:null_pos
+    return s:null_range
+  endif
   if s:pos_less_equal(start, end_backward)
     return s:null_range
   endif

--- a/test/test_files/test.go
+++ b/test/test_files/test.go
@@ -1,0 +1,23 @@
+package main
+
+`go`
+
+/*
+
+`go`
+
+*/
+
+`go`
+func hoge() string {
+	return ""
+}
+
+/*
+
+`c`
+
+*/
+import "C"
+
+`go`


### PR DESCRIPTION
Works fine for a file with single C-style comment,  but does not work for a file with multi C-style comments.

I suppose that range searching scheme of current context_filetype.vim sometimes does not work correctly. By example:

```
1 /*
2 */
3 
4 /*
5 */
6 import "C"
```

We expect [4, 6]
But start pattern matches Line 1 and end pattern matches Line 6; [1, 6].
