### PR TITLE
Add dynamic file type detection for .vue

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -170,8 +170,8 @@ let s:default_filetypes = {
       \ 'vue': [
       \   {
       \    'start':
-      \     '<template\%( [^>]*\)\? lang="pug"\%( [^>]*\)\?>',
-      \    'end': '</template>', 'filetype': 'pug',
+      \     '<template\%( [^>]*\)\? \%(lang="\%(\(\h\w*\)\)"\)\%( [^>]*\)\?>',
+      \    'end': '</template>', 'filetype': '\1',
       \   },
       \   {
       \    'start':
@@ -185,8 +185,18 @@ let s:default_filetypes = {
       \   },
       \   {
       \    'start':
+      \     '<script\%( [^>]*\)\? \%(lang="\%(\(\h\w*\)\)"\)\%( [^>]*\)\?>',
+      \    'end': '</script>', 'filetype': '\1',
+      \   },
+      \   {
+      \    'start':
       \     '<script\%( [^>]*\)\?>',
       \    'end': '</script>', 'filetype': 'javascript',
+      \   },
+      \   {
+      \    'start':
+      \     '<style\%( [^>]*\)\? \%(lang="\%(\(\h\w*\)\)"\)\%( [^>]*\)\?>',
+      \    'end': '</style>', 'filetype': '\1',
       \   },
       \   {
       \    'start':


### PR DESCRIPTION
以前 issue #34 でも同じような報告をさせていただきましたが、 template の pug だけでなく style や script に対しても動的に識別できる方が都合が良いため自分で修正を加えてみました。

VimのプラグインにMRを出すのは初めてで正規表現も正しく書けているか自信がないので、何か問題があれば教えていただければ幸いです。よろしくお願いします。