### PR TITLE
Support multiline start pattern back reference and asciidoc filetype

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -484,7 +484,8 @@ function! s:search_range(start_pattern, end_pattern)
 
   let end_pattern = a:end_pattern
   if end_pattern =~ '\\\d\+'
-    let match_list = matchlist(getline(start[0]), a:start_pattern)
+    let lines = getline(start[0], line("."))
+    let match_list = matchlist(join(lines, "\n"), a:start_pattern)
     let end_pattern = s:replace_submatch(end_pattern, match_list)
   endif
 
@@ -547,10 +548,11 @@ function! s:get_context(filetype, context_filetypes, search_range)
       let context_filetype = context.filetype
       if context.filetype =~ '\\\d\+'
         let stopline_back = s:stopline_back()
-        let line = getline(
-              \ searchpos(context.start, 'nbW', stopline_back)[0]
+        let lines = getline(
+              \ searchpos(context.start, 'nbW', stopline_back)[0],
+              \ line(".")
               \ )
-        let match_list = matchlist(line, context.start)
+        let match_list = matchlist(join(lines, "\n"), context.start)
         let context_filetype = s:replace_submatch(context.filetype, match_list)
       endif
       return { "filetype" : context_filetype, "range" : range }

--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -359,6 +359,16 @@ let s:default_filetypes = {
       \    'end': '$', 'filetype': 'c',
       \   },
       \ ],
+      \ 'asciidoc': [
+      \   {
+      \    'start' : '^\[source\%(%[^,]*\)\?,\(\h\w*\)\(,.*\)\?\]\s*\n----\s*\n',
+      \    'end' : '^----\s*$', 'filetype' : '\1',
+      \   },
+      \   {
+      \    'start' : '^\[source\%(%[^,]*\)\?,\(\h\w*\)\(,.*\)\?\]\s*\n',
+      \    'end' : '^$', 'filetype' : '\1',
+      \   },
+      \ ],
 \}
 
 


### PR DESCRIPTION
AsciiDoc / AsciiDoctor ファイルタイプのサポートを追加しました
https://asciidoctor.org/docs/user-manual/#applying-source-highlighting

AsciiDoc では開始パターンが複数行になるため `\1` の後方参照がうまく機能していなかった点に修正を加えています。

ただし、この修正によるパフォーマンス低下などの影響があるかもしれません。