### PR TITLE
Fix submatch support

### DIFF
--- a/doc/context_filetype.txt
+++ b/doc/context_filetype.txt
@@ -54,15 +54,6 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 		Because it is complicated, refer to s:initialize() in
 		autoload/context_filetype.vim for the initial value.
 
-		NOTE: If you change the magic-ness of an "end" pattern,
-		change the magic-ness again immediately after each backref,
-		even if you repeat the previous change.
-		E.g., '\vfoo\1\vbar'.
-		(Internally, a "\m" is inserted into the pattern after each
-		backref, but do not rely on this.)
-		If your patterns do not contain "\m", "\M", "\v", or "\V",
-		all this can be safely ignored.
-
 b:context_filetype_filetypes			*b:context_filetype_filetypes*
 		It is the buffer variable version of
 		|g:context_filetype#filetypes|.

--- a/doc/context_filetype.txt
+++ b/doc/context_filetype.txt
@@ -33,8 +33,13 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 		The keys and values are below.
 		"filetype" : includes filetype name.
 		"start" : filetype start pattern.
-		"end" : filetype end pattern.  You can use \1 to refer start's
-			matched pattern.
+		"end" : filetype end pattern.
+
+		The patterns in "start" and "end" are always interpreted as if
+		'magic' is set, ignoring the actual value of the 'magic'
+		option.
+		You can use "\0" through "\9" to refer to "start"'s match and
+		sub-matches in "end" and "filetype".
 >
 		" Examples:
 		if !exists('g:context_filetype#filetypes')
@@ -48,6 +53,15 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 <
 		Because it is complicated, refer to s:initialize() in
 		autoload/context_filetype.vim for the initial value.
+
+		NOTE: If you change the magic-ness of an "end" pattern,
+		change the magic-ness again immediately after each backref,
+		even if you repeat the previous change.
+		E.g., '\vfoo\1\vbar'.
+		(Internally, a "\m" is inserted into the pattern after each
+		backref, but do not rely on this.)
+		If your patterns do not contain "\m", "\M", "\v", or "\V",
+		all this can be safely ignored.
 
 b:context_filetype_filetypes			*b:context_filetype_filetypes*
 		It is the buffer variable version of


### PR DESCRIPTION
The original (ba01640) would only match the first invocation, and also was unsafe in patterns.

This patch breaks "end" patterns utilizing a backref to a Vim pattern embedded within the referenced "start" submatch. I see this behavior as pretty unexpected (and not that portable), so these sub-matches will now be matched literally.

See commit messages for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shougo/context_filetype.vim/44)
<!-- Reviewable:end -->
