### PR TITLE
feat: markdown front matter support (yaml header)

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -325,6 +325,10 @@ let s:default_filetypes = {
       \    'start' : '^\s*```\s*\(\h\w*\)',
       \    'end' : '^\s*```$', 'filetype' : '\1',
       \   },
+      \   {
+      \    'start' : '\%^-\{3,}.*$',
+      \    'end' : '\_^-\{3,}.*$', 'filetype' : 'yaml'
+      \   },
       \ ],
       \ 'haml': [
       \   {


### PR DESCRIPTION
Markdown file first header block (FrontMatter) support.
FrontMatter as yaml.

```markdown
---
title: ""
...
---

# First H1
...
```