### PR TITLE
feat: ftplugin in toml for dein.vim

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -367,8 +367,9 @@ let s:default_filetypes = {
       \ ],
       \ 'toml': [
       \   {
-      \    'start': '\<hook_\%('.
+      \    'start': '\<\%(hook_\%('.
       \             'add\|source\|post_source\|post_update'.
+      \             '\)\|[_a-z]\+'.
       \             '\)\s*=\s*\('."'''".'\|"""\)',
       \    'end': '\1', 'filetype': 'vim',
       \   },


### PR DESCRIPTION
Hi, I added a support for toml for dein.vim.
While `hook_**` has been supported, `[ftplugin]` and `[plugins.ftplugin]` haven't.


```
[ftplugin]
_ = '''
setlocal formatoptions-=r
setlocal formatoptions-=o
'''
```

