### PR TITLE
fix: context_filetype#default_filetypes() typo

### DIFF
--- a/autoload/context_filetype.vim
+++ b/autoload/context_filetype.vim
@@ -87,7 +87,7 @@ function! context_filetype#get_range(...) abort
 endfunction
 
 function! context_filetype#default_filetypes() abort
-  return deepcopy(g:context_filetype#default#_filetypes)
+  return deepcopy(g:context_filetype#defaults#_filetypes)
 endfunction
 
 function! context_filetype#filetypes() abort


### PR DESCRIPTION
## Description

API context_filetype#default_filetypes() fix.

## Problem

Call above function, error happen.

```
[dein] Error occurred while executing hook: context_filetype.vim
[dein] Vim(return):E121: 未定義の変数です: g:context_filetype#default#_filetypes
```

## Impurity commit

commit 85cf342225b460324754ceaadcd77d7a6659d608 has typo