### PR TITLE
tex in markdown (display mode)

### DIFF
--- a/autoload/context_filetype/defaults.vim
+++ b/autoload/context_filetype/defaults.vim
@@ -229,12 +229,12 @@ let g:context_filetype#defaults#_filetypes = {
       \    'end' : '\_^-\{3,}.*$', 'filetype' : 'yaml'
       \   },
       \   {
-      \    'start' : '^\s*\\\[$',
-      \    'end' : '^\s*\\\]$', 'filetype' : 'tex'
+      \    'start' : '\\(',
+      \    'end' : '\\)', 'filetype' : 'tex'
       \   },
       \   {
-      \    'start' : '^\s*\$\$$',
-      \    'end' : '^\s*\$\$$', 'filetype' : 'tex'
+      \    'start' : '\\[',
+      \    'end' : '\\]', 'filetype' : 'tex'
       \   },
       \ ],
       \ 'haml': [

--- a/autoload/context_filetype/defaults.vim
+++ b/autoload/context_filetype/defaults.vim
@@ -228,6 +228,14 @@ let g:context_filetype#defaults#_filetypes = {
       \    'start' : '\%^-\{3,}.*$',
       \    'end' : '\_^-\{3,}.*$', 'filetype' : 'yaml'
       \   },
+      \   {
+      \    'start' : '^\s*\\\[$',
+      \    'end' : '^\s*\\\]$', 'filetype' : 'tex'
+      \   },
+      \   {
+      \    'start' : '^\s*\$\$$',
+      \    'end' : '^\s*\$\$$', 'filetype' : 'tex'
+      \   },
       \ ],
       \ 'haml': [
       \   {

--- a/doc/context_filetype.jax
+++ b/doc/context_filetype.jax
@@ -98,6 +98,8 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 		"filetype" : 判定を行う filetype
 			      "end" または "filetype" に \1 が設定されている場
 			      合は "start" にマッチした値になります。
+
+		"start"、"end" パターンは異なるものを指定する必要があります。
 >
 		" Examples:
 		let g:context_filetype#filetypes = {

--- a/doc/context_filetype.jax
+++ b/doc/context_filetype.jax
@@ -75,6 +75,7 @@ CONTENTS					*context_filetype-contents*
  css
 
 - "markdown"
+ mathjax
 
 - "haml"
  ruby

--- a/doc/context_filetype.txt
+++ b/doc/context_filetype.txt
@@ -34,6 +34,7 @@ g:context_filetype#filetypes			*g:context_filetype#filetypes*
 		"filetype" : includes filetype name.
 		"start" : filetype start pattern.
 		"end" : filetype end pattern.
+		Note that "start" and "end" patterns shouldn't be identical.
 
 		The patterns in "start" and "end" are always interpreted as if
 		'magic' is set, ignoring the actual value of the 'magic'


### PR DESCRIPTION
I added mathjax support.
There are some usual ways:
- `\[` ~ `\]`
- `\(` ~ `\)`
- `$$` ~ `$$`

The last one is not supported by the present implementation, so I add the former two.
I also added a note in doc.